### PR TITLE
Increased version of dependency to vertx.core. This fixes a build error ...

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@
 version=1.0.0-SNAPSHOT
 group=io.vertx
 gradleVersion=1.5
-vertxVersion=2.1M2-SNAPSHOT
+vertxVersion=2.1.1
 junitVersion=4.11


### PR DESCRIPTION
...that occurs because the milestone artifact for 2.1M2-SNAPSHOT cannot be found on Maven Central anymore. Fixes #19.
